### PR TITLE
Allow calls to respond_to? to search for private/protected methods.

### DIFF
--- a/lib/lightning/builder.rb
+++ b/lib/lightning/builder.rb
@@ -21,7 +21,7 @@ module Lightning
 
     # @return [Boolean] Determines if Builder can build a file for its current shell
     def can_build?
-      respond_to? "#{shell}_builder"
+      respond_to? "#{shell}_builder", true
     end
 
     # @return [String] Current shell, defaults to 'bash'

--- a/lib/lightning/generator.rb
+++ b/lib/lightning/generator.rb
@@ -76,7 +76,7 @@ module Lightning
     end
 
     def call_generator(gen, strict=true)
-      if @underling.respond_to?(gen)
+      if @underling.respond_to? gen, true
         Array(@underling.send(gen)).map {|e| e.to_s }
       elsif strict
         raise("Generator method doesn't exist.")


### PR DESCRIPTION
First time I've used this library in quite a while. Of course, I wasn't able to create new functions. Lightning kept complaining there was no builder for zsh. Huh? How it ever worked in the past I can't say but the fix was just adding a second boolean param to the respond_to? method call so it could search for protected methods.

There was another call to respond_to? in generator.rb that made for some more errors on the tests. 

All test pass now. Btw, bacon-bits has a redundant piece of code that is included in bacon 1.2.0 and bacon-rr makes a deprecated reference but it's handled. Tests pass so this makes no apparent difference. 